### PR TITLE
Node refactor

### DIFF
--- a/lib/gpi/canvasGraph.py
+++ b/lib/gpi/canvasGraph.py
@@ -430,11 +430,9 @@ class GraphWidget(QtGui.QGraphicsView):
             nodes = self.getAllNodes()
             cnt = 0
             for node in nodes:
-                if node._nodeAPI:  # protect against deleted object
-                    if node._nodeAPI.reQueueIsSet() and \
-                            not node.inDisabledState():
-                        node.setEventStatus({GPI_REQUEUE_EVENT: None})
-                        cnt += 1
+                if node.reQueueIsSet() and not node.inDisabledState():
+                    node.setEventStatus({GPI_REQUEUE_EVENT: None})
+                    cnt += 1
             if cnt:  # if any nodes got reset then start loop
                 self._switchSig.emit('requeue')
                 return
@@ -695,7 +693,7 @@ class GraphWidget(QtGui.QGraphicsView):
             print(("node: " + str(node.name)))
             print(("inDisabledState: " + str(node.inDisabledState())))
             print(("hasEventPending: " + str(node.hasEventPending())))
-            print(("_nodeAPI.reQueueIsSet: " + str(node._nodeAPI.reQueueIsSet())))
+            print(("_nodeAPI.reQueueIsSet: " + str(node.reQueueIsSet())))
             print("________________________")
 
     def setPauseState(self, val):

--- a/lib/gpi/canvasGraph.py
+++ b/lib/gpi/canvasGraph.py
@@ -1819,7 +1819,7 @@ class GraphWidget(QtGui.QGraphicsView):
                 except:
                     log.error(stw(node.getModuleName()) + ' has no walltime but walltime was saved as NoneType, skipping...')
 
-            node.loadNodeIFSettings(s['widget_settings'])
+            node.loadNodeUISettings(s['widget_settings'])
 
         # place all macro nodes on the canvas and load settings
         #   -done after node instantiation so that widgets can be copied over

--- a/lib/gpi/canvasGraph.py
+++ b/lib/gpi/canvasGraph.py
@@ -303,7 +303,7 @@ class GraphWidget(QtGui.QGraphicsView):
             # load nodes
             if Commands.modCount():
                 for path in Commands.mods():
-                    
+
                     pos = self.getEventPos_randomDev(rad=50)
                     pos = QtCore.QPoint(pos.x(), pos.y())
 
@@ -337,7 +337,7 @@ class GraphWidget(QtGui.QGraphicsView):
                         arg = Commands.stringNodeArg(lab)
 
                         # set 'string' widget value
-                        node._nodeIF.modifyWidget_direct('string', val=arg)
+                        node._nodeUI.modifyWidget_direct('string', val=arg)
                         node.setEventStatus({GPI_WIDGET_EVENT: 'string'})
                     else:
                         log.warn('String node label: \''+str(lab)+'\' not found, skipping.')
@@ -430,8 +430,8 @@ class GraphWidget(QtGui.QGraphicsView):
             nodes = self.getAllNodes()
             cnt = 0
             for node in nodes:
-                if node._nodeIF:  # protect against deleted object
-                    if node._nodeIF.reQueueIsSet() and \
+                if node._nodeAPI:  # protect against deleted object
+                    if node._nodeAPI.reQueueIsSet() and \
                             not node.inDisabledState():
                         node.setEventStatus({GPI_REQUEUE_EVENT: None})
                         cnt += 1
@@ -512,10 +512,10 @@ class GraphWidget(QtGui.QGraphicsView):
             et = lambda :GPI_APPLOOP
 
             # GPI_THREAD & beta_spiral.net causes: 64119 Bus error: 10
-            #et = lambda :GPI_THREAD 
+            #et = lambda :GPI_THREAD
 
             newnode.execType = et
-            newnode._nodeIF.execType = et
+            newnode._nodeAPI.execType = et
 
         newnode.refreshName()
         self.scene().addItem(newnode)
@@ -534,7 +534,7 @@ class GraphWidget(QtGui.QGraphicsView):
         if type(sig['subsig']) == NodeCatalogItem:
             log.debug('addNode by item')
             item = sig['subsig']
-           
+
             # get the position of menu invocation
             radius = 10.0  # pts
             x = self._event_pos.x() + random.random() * radius
@@ -575,7 +575,7 @@ class GraphWidget(QtGui.QGraphicsView):
             if node is None:
                 log.error('\''+str(item.node)+'\' could not be located for \''+str(item.ext)+'\'')
             else:
-                node._nodeIF.modifyWidget_direct(item.wdg, val=sig['path'])
+                node._nodeUI.modifyWidget_direct(item.wdg, val=sig['path'])
                 self.scene().unselectAllItems()
                 node.setSelected(True)
                 node.setEventStatus({GPI_WIDGET_EVENT: item.wdg})
@@ -591,7 +591,7 @@ class GraphWidget(QtGui.QGraphicsView):
                 net = self._network.loadNetworkFromFile(sig['path'])
                 if net:
                     self.deserializeCanvas(net, self.getEventPos_randomDev())
-                
+
         elif sig['subsig'] == 'dialog':
             if 'pos' in sig:
                 net = self._network.loadNetworkFromFileDialog()
@@ -695,7 +695,7 @@ class GraphWidget(QtGui.QGraphicsView):
             print(("node: " + str(node.name)))
             print(("inDisabledState: " + str(node.inDisabledState())))
             print(("hasEventPending: " + str(node.hasEventPending())))
-            print(("_nodeIF.reQueueIsSet: " + str(node._nodeIF.reQueueIsSet())))
+            print(("_nodeAPI.reQueueIsSet: " + str(node._nodeAPI.reQueueIsSet())))
             print("________________________")
 
     def setPauseState(self, val):
@@ -735,7 +735,7 @@ class GraphWidget(QtGui.QGraphicsView):
 
         #scrollArea.show()
         #scrollArea.raise_()
-        
+
         layoutwindow.show()
         layoutwindow.raise_()
 
@@ -755,7 +755,7 @@ class GraphWidget(QtGui.QGraphicsView):
 
         #scrollArea.show()
         #scrollArea.raise_()
-        
+
         layoutwindow.show()
         layoutwindow.raise_()
 
@@ -815,7 +815,7 @@ class GraphWidget(QtGui.QGraphicsView):
                     poses.append(event.pos() + rand)
 
             # process each dropped path
-            for path, pos in zip(paths, poses): 
+            for path, pos in zip(paths, poses):
 
                 log.debug('Dropped uri: '+str(path))
 
@@ -857,7 +857,7 @@ class GraphWidget(QtGui.QGraphicsView):
                     return
 
             # shows rejected animation if not called
-            event.acceptProposedAction()  
+            event.acceptProposedAction()
 
     def dragLeaveEvent(self, event):
         event.accept()
@@ -1010,7 +1010,7 @@ class GraphWidget(QtGui.QGraphicsView):
         '''
         wdgid = int(wdgid)
         for node in nodeList:
-            for parm in node._nodeIF.parmList:
+            for parm in node._nodeAPI.parmList:
                 if parm.get_id() == wdgid:
                     return parm
 
@@ -1229,7 +1229,7 @@ class GraphWidget(QtGui.QGraphicsView):
         '''Reload, instantiate, and reconnect the selected node.
                 -Only allow one node.
         '''
-        nodes = self.getSelectedNodes() 
+        nodes = self.getSelectedNodes()
 
         if len(nodes) == 0:
             return
@@ -1240,7 +1240,7 @@ class GraphWidget(QtGui.QGraphicsView):
             self.pauseToggle(quiet=True)
 
         # copy
-        self.copyNodesToBuffer() 
+        self.copyNodesToBuffer()
 
         # delete node
         for node in nodes:
@@ -1368,7 +1368,7 @@ class GraphWidget(QtGui.QGraphicsView):
 
         #mark_font = QtGui.QFont(u"gill sans", 50)
         #fm = QtGui.QFontMetricsF(mark_font)
-        #bw = fm.width(message) * 1.12 
+        #bw = fm.width(message) * 1.12
 
         #bh = fm.height()
         # centered
@@ -1524,7 +1524,7 @@ class GraphWidget(QtGui.QGraphicsView):
             # main menu
             menu = QtGui.QMenu(self.parent)
 
-            # search 
+            # search
             qle = QtGui.QLineEdit()
             qle.setContextMenuPolicy(QtCore.Qt.NoContextMenu)
             qle.setPlaceholderText('  Search')
@@ -1628,7 +1628,7 @@ class GraphWidget(QtGui.QGraphicsView):
                 #self._switchSig.emit('deleteAll')  # change state
 
                 reply = QtGui.QMessageBox.question(self, 'Message',
-                            "Delete all modules on this canvas?", QtGui.QMessageBox.Yes | 
+                            "Delete all modules on this canvas?", QtGui.QMessageBox.Yes |
                                 QtGui.QMessageBox.No, QtGui.QMessageBox.No)
 
                 if reply == QtGui.QMessageBox.Yes:
@@ -1649,7 +1649,7 @@ class GraphWidget(QtGui.QGraphicsView):
                 #self._switchSig.emit('pause')
                 #self.closeGraph(event)
                 #QtGui.qApp.quit()
-            
+
             self.parent.statusBar().clearMessage()
 
     def setStatusTip(self, msg):
@@ -1704,7 +1704,7 @@ class GraphWidget(QtGui.QGraphicsView):
 
     def closeGraphWithDialog(self):
         reply = QtGui.QMessageBox.question(self, 'Message',
-                    "Close canvas without saving?", QtGui.QMessageBox.Yes | 
+                    "Close canvas without saving?", QtGui.QMessageBox.Yes |
                         QtGui.QMessageBox.No, QtGui.QMessageBox.No)
 
         if reply == QtGui.QMessageBox.Yes:
@@ -1876,7 +1876,7 @@ class GraphWidget(QtGui.QGraphicsView):
         for lw in layoutSettings:
             self.newLayoutWindowFromSettings(lw, buf)
 
-        # reset node IDs, and widget IDs 
+        # reset node IDs, and widget IDs
         for node in buf:
             node.setID()
             for parm in node.getParmList():
@@ -2025,7 +2025,7 @@ class GraphWidget(QtGui.QGraphicsView):
         network['WALLTIME'] = str(self.walltime())  # sec
         network['TOTAL_PMEM'] = str(self.totalPortMem())  # bytes
         return network
-   
+
     def deserializeCanvas(self, network, pos):
         # convert the loaded file data into the format required by GPI objects
         # and instantiate the network on the canvas.

--- a/lib/gpi/config.py
+++ b/lib/gpi/config.py
@@ -458,4 +458,4 @@ class ExternalNode(gpi.NodeAPI):
 # activate this upon first import
 Config = ConfigManager()
 
-#print Config
+# print(Config)

--- a/lib/gpi/defaultTypes.py
+++ b/lib/gpi/defaultTypes.py
@@ -124,5 +124,7 @@ class GPIDefaultType(object):
             setter = "set_"+k
             if hasattr(self, setter):
                 getattr(self, setter)(v)
+            elif k == 'changed':
+                pass
             else:
                 log.warn('No attribute \''+str(k)+'\' in port-type \''+str(GPITYPE_PASS)+'\',\n\t\tCheck your requested port-type in addInPort() or addOutPort().')

--- a/lib/gpi/functor.py
+++ b/lib/gpi/functor.py
@@ -79,14 +79,14 @@ class GPIFunctor(QtCore.QObject):
         self._segmentedDataProxy = False
 
         # For Windows just make them all apploops for now to be safe
-        self._execType = node._nodeIF.execType()
+        self._execType = node._nodeAPI.execType()
         if Specs.inWindows() and (self._execType == GPI_PROCESS):
         #if (self._execType == GPI_PROCESS):
             log.info("init(): <<< WINDOWS Detected >>> Forcing GPI_PROCESS -> GPI_THREAD")
             self._execType = GPI_THREAD
             #self._execType = GPI_APPLOOP
 
-        self._label = node._nodeIF.getLabel()
+        self._label = node._nodeAPI.getLabel()
         self._isTerminated = False
         self._compute_start = 0
 
@@ -159,7 +159,7 @@ class GPIFunctor(QtCore.QObject):
 
         if self._execType == GPI_PROCESS:
             log.debug("start(): buffer process parms")
-            self._node._nodeIF.bufferParmSettings()
+            self._node._nodeAPI.bufferParmSettings()
 
             # keep objects on death-row from being copied into processes
             # before they've finally terminated. -otherwise they'll try
@@ -314,7 +314,7 @@ class GPIFunctor(QtCore.QObject):
 
         if self._retcode == -1:
             self.applyQueuedData_Failed()
-        
+
         elapsed = (time.time() - self._ap_st_time)
         log.info("applyQueuedData(): time (total queue): "+str(elapsed)+" sec")
 

--- a/lib/gpi/functor.py
+++ b/lib/gpi/functor.py
@@ -210,6 +210,7 @@ class GPIFunctor(QtCore.QObject):
     def applyQueuedData_setData(self):
 
         for o in self._proxy:
+            print(o)
             try:
                 log.debug("applyQueuedData_setData(): apply object "+str(o[0])+', '+str(o[1]))
                 #if o[0] == 'retcode':

--- a/lib/gpi/loader.py
+++ b/lib/gpi/loader.py
@@ -97,6 +97,8 @@ def loadMod(fullpath):
 
     # exclude the file extension to allow reloads
     store_name, ext = os.path.splitext(fullpath)
+    node_dir, store_name = os.path.split(store_name)
+    appendSysPath(node_dir)
     if ext not in GPI_PYMOD_EXTS:
         log.error('The filename is not a valid pymod: '+str(fullpath))
         return None
@@ -108,7 +110,7 @@ def loadMod(fullpath):
     # load .py
     if ext == '.py':
 
-        # only attempt compilation if the directory is writeable 
+        # only attempt compilation if the directory is writeable
         #   -this helps with distributed libraries.
         if os.access(os.path.dirname(fullpath), os.W_OK):
 

--- a/lib/gpi/node.py
+++ b/lib/gpi/node.py
@@ -590,6 +590,10 @@ class Node(QtGui.QGraphicsItem):
         self._switchSig.emit('error')
 
     def computeRun(self, sig):
+        self._nodeAPI.updateWidgets(self._nodeUI.getWidgets())
+        # self._nodeAPI.updatePorts(self._nodeUI.getInPorts(),
+        #                           self._nodeUI.getOutPorts())
+        # self._nodeAPI.updateEvents(self.getPendingEvents())
         self.printCurState()
         self._curState.emit('Compute ('+str(sig)+')')
         try:
@@ -879,8 +883,8 @@ class Node(QtGui.QGraphicsItem):
         o = []
         for p in self.getPorts():
             o.append(p.getName())
-        for w in self._nodeUI.getWidgets():
-            o.append(str(w.title()))
+        for w in self._nodeUI.getWidgets().keys():
+            o.append(w)
         return o
 
     def setID(self, value=None):

--- a/lib/gpi/node.py
+++ b/lib/gpi/node.py
@@ -592,7 +592,7 @@ class Node(QtGui.QGraphicsItem):
         self.printCurState()
         self._curState.emit('Post Compute ('+str(sig)+')')
         try:
-            self._nodeUI.post_compute_widget_update()
+            self._nodeUI.post_compute_widget_update(self._nodeAPI.getWidgets())
             self.setWidgetOutports()
             self.updateToolTips()  # for ports
             self.updateToolTip()  # for node
@@ -912,7 +912,7 @@ class Node(QtGui.QGraphicsItem):
     def removeMenu(self):
         # close widgets
         if self._nodeUI: # macro safe
-            for parm in self._nodeUI.getParmList():
+            for parm in self.getParmList():
                 try:
                     if parm.parent() is self._nodeUI:  # not sure if this protects against
                         # c++ wrapper already deleted error
@@ -1121,8 +1121,6 @@ class Node(QtGui.QGraphicsItem):
         if port.dataHasChanged():
             port.setDownstreamEvents()
         port.update()
-        # allow gui update so port status can be seen
-        # QtGui.QApplication.processEvents()
 
     def isTopNode(self):
         cnt = 0
@@ -1185,7 +1183,7 @@ class Node(QtGui.QGraphicsItem):
                 return True
         # print type(self)
         if self._nodeAPI:
-            for wdg in self._nodeUI.getParmList():
+            for wdg in self.getParmList():
                 if wdg.getTitle() == title:
                     return True
         return False

--- a/lib/gpi/node.py
+++ b/lib/gpi/node.py
@@ -611,7 +611,6 @@ class Node(QtGui.QGraphicsItem):
 
             # configure the node API before starting the thread
             self._nodeAPI.config(self.getID(),
-                                 self.nodeCompute_thread,
                                  self.nodeCompute_thread.execType())
 
             self.nodeCompute_thread.start()
@@ -1093,7 +1092,7 @@ class Node(QtGui.QGraphicsItem):
             self._menuHasRaised = False
 
     def getModuleCompute(self):
-        return self._nodeAPI.compute
+        return self._nodeAPI._compute
 
     def getModuleValidate(self):
         return self._nodeAPI.validate

--- a/lib/gpi/node.py
+++ b/lib/gpi/node.py
@@ -425,8 +425,8 @@ class Node(QtGui.QGraphicsItem):
                 ret = self._nodeAPI.initUI_return()
                 if ret in (None, 0):
                     self._nodeUI.initUI(self._nodeAPI.getWidgets(),
-                                        None,
-                                        None,
+                                        self._nodeAPI.getInPorts(),
+                                        self._nodeAPI.getOutPorts(),
                                         self.item)
                 elif ret > 0:
                     self._machine.next('init_warn')

--- a/lib/gpi/nodeAPI.py
+++ b/lib/gpi/nodeAPI.py
@@ -691,13 +691,13 @@ class NodeAPI(QtGui.QWidget):
         # Why is this trying the scrollArea? isn't it always a scroll???
         if self.label == '':
             try:
-                self.node._nodeIF_scrollArea.setWindowTitle(self.node.name)
+                self.node._nodeUI_scrollArea.setWindowTitle(self.node.name)
             except:
                 self.setWindowTitle(self.node.name)
         else:
             try:
                 augtitle = self.node.name + ": " + self.label
-                self.node._nodeIF_scrollArea.setWindowTitle(augtitle)
+                self.node._nodeUI_scrollArea.setWindowTitle(augtitle)
             except:
                 augtitle = self.node.name + ": " + self.label
                 self.setWindowTitle(augtitle)
@@ -772,7 +772,7 @@ class NodeAPI(QtGui.QWidget):
                     # for split objects to pass thru individually
                     # this will be a list of DataProxy objects
                     if type(s) is list:
-                        for i in s: 
+                        for i in s:
                             self.node.nodeCompute_thread.addToQueue(['setData', title, i])
                     # a single DataProxy object
                     else:
@@ -881,7 +881,7 @@ class NodeAPI(QtGui.QWidget):
         '''Allow node developer to get information about what event has caused
         the node to run.'''
         return self.node.getPendingEvents().events
-    
+
     def portEvents(self):
         '''Specifically check for a port event.  Widget-ports count as both.'''
         return self.node.getPendingEvents().port

--- a/lib/gpi/nodeAPI.py
+++ b/lib/gpi/nodeAPI.py
@@ -49,6 +49,28 @@ log = manager.getLogger(__name__)
 # for PROCESS data hack
 import numpy as np
 
+# Developer Interface Exceptions
+class GPIError_nodeAPI_setData(Exception):
+    def __init__(self, value):
+        super().__init__(value)
+
+class GPIError_nodeAPI_getData(Exception):
+    def __init__(self, value):
+        super().__init__(value)
+
+class GPIError_nodeAPI_setAttr(Exception):
+    def __init__(self, value):
+        super().__init__(value)
+
+class GPIError_nodeAPI_getAttr(Exception):
+    def __init__(self, value):
+        super().__init__(value)
+
+class GPIError_nodeAPI_getVal(Exception):
+    def __init__(self, value):
+        super().__init__(value)
+
+
 class NodeAPI:
     '''This is the class that all external modules must implement.'''
     GPIExtNodeType = ExternalNodeType  # ensures the subclass is of THIS class
@@ -143,20 +165,6 @@ class NodeAPI:
         # return GPI_THREAD
         return GPI_PROCESS  # this is the safest
         # return GPI_APPLOOP
-
-    # TODO: move to node.py? All results here acces the node instance anyway...
-    # def setReQueue(self, val=False):  # NODEAPI
-    #     # At the end of a nodeQueue, these tasked are checked for
-    #     # more events.
-    #     if self.node.inDisabledState():
-    #         return
-    #     if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
-    #         self.node.nodeCompute_thread.addToQueue(['setReQueue', val])
-    #     else:
-    #         self.node._requeue = val
-
-    # def reQueueIsSet(self):
-    #     return self.node._requeue
 
     def getLabel(self):
         return self._label

--- a/lib/gpi/nodeAPI.py
+++ b/lib/gpi/nodeAPI.py
@@ -210,14 +210,16 @@ class NodeAPI:
 
     # TODO: needs to basically just return self._widgets, I think, but maybe it
     # should be re-structured to serialize in the way it did before?
-    # def getSettings(self):  # NODEAPI
-    #     '''Wrap up all settings from each widget.'''
-    #     s = {}
-    #     s['label'] = self.label
-    #     s['parms'] = []
-    #     for parm in self.parmList:
-    #         s['parms'].append(copy.deepcopy(parm.getSettings()))
-    #     return s
+    def getSettings(self):  # NODEAPI
+        '''Wrap up all settings from each widget.'''
+        s = {}
+        s['label'] = self._label
+        s['parms'] = []
+        for title, parms in self._widgets.items():
+            parm_dict = {'title' : title}
+            parm_dict.update(parms)
+            s['parms'].append(parm_dict)
+        return s
 
     def loadSettings(self, s):
         self.setLabelWidget(s['label'])
@@ -333,7 +335,7 @@ class NodeAPI:
 
     def printWidgetValues(self):
         # for debugging
-        for widget_name, wdg in self._widgets:
+        for widget_name, wdg in self._widgets.items():
             log.debug("widget: " + widget_name)
             log.debug("value: " + wdg['val'])
 
@@ -383,7 +385,7 @@ class NodeAPI:
             return
 
         # check existence first
-        if title in self.widgets.keys():
+        if title in self._widgets.keys():
             log.critical("addWidget(): Widget title \'" + str(title) \
                 + "\' is already in use! Aborting.")
             return
@@ -620,6 +622,7 @@ class NodeAPI:
         '''
         pass
 
+    # TODO: deprecate in user API?
     def getWidget(self, pnum):
         '''Returns the widget desc handle and position number'''
         # fetch by widget number

--- a/lib/gpi/nodeUI.py
+++ b/lib/gpi/nodeUI.py
@@ -532,13 +532,13 @@ class NodeUI(QtGui.QWidget):
         # Why is this trying the scrollArea? isn't it always a scroll???
         if self.label == '':
             try:
-                self.node._nodeIF_scrollArea.setWindowTitle(self.node.name)
+                self.node._nodeUI_scrollArea.setWindowTitle(self.node.name)
             except:
                 self.setWindowTitle(self.node.name)
         else:
             try:
                 augtitle = self.node.name + ": " + self.label
-                self.node._nodeIF_scrollArea.setWindowTitle(augtitle)
+                self.node._nodeUI_scrollArea.setWindowTitle(augtitle)
             except:
                 augtitle = self.node.name + ": " + self.label
                 self.setWindowTitle(augtitle)

--- a/lib/gpi/nodeUI.py
+++ b/lib/gpi/nodeUI.py
@@ -794,87 +794,20 @@ class NodeUI(QtGui.QWidget):
         except:
             raise GPIError_nodeAPI_getData('self.getData(\''+stw(title)+'\') failed in the node definition check the port name.')
 
+    def getPortData(self):
+        port_data = {}
+        for port in self.node.inportList:
+            port_data[port.portTitle] = {'data' : port.getUpstreamData()}
+        for port in self.node.outportList:
+            port_data[port.portTitle] = {'data' : port._data}
+        return port_data
+
     # TODO: deprecate these?
     def getInPort(self, pnumORtitle):
         return self.node.getInPort(pnumORtitle)
 
     def getOutPort(self, pnumORtitle):
         return self.node.getOutPort(pnumORtitle)
-
-############### DEPRECATED NODE API
-# TTD v0.3
-
-    def getAttr_fromWdg(self, title, attr):
-        """title = (str) wdg-class name
-        attr = (str) corresponds to the get_<arg> of the desired attribute.
-        """
-        log.warn('The \'getAttr_fromWdg()\' function is deprecated, use \'getAttr()\' instead.  '+str(self.node.getFullPath()))
-        return self.getAttr(title, attr)
-
-    def getVal_fromParm(self, title):
-        """Returns get_val() from wdg-class (see getAttr()).
-        """
-        log.warn('The \'getVal_fromParm()\' function is deprecated, use \'getVal()\' instead.  '+str(self.node.getFullPath()))
-        return self.getVal(title)
-
-    def getData_fromPort(self, title):
-        """title = (str) the name of the InPort.
-        """
-        log.warn('The \'getData_fromPort()\' function is deprecated, use \'getData()\' instead.  '+str(self.node.getFullPath()))
-        return self.getData(title)
-
-    def setData_ofPort(self, title, data):
-        """title = (str) name of the OutPort to send the object reference.
-        data = (object) any object corresponding to a GPIType class.
-        """
-        log.warn('The \'setData_ofPort()\' function is deprecated, use \'setData()\' instead.  '+str(self.node.getFullPath()))
-        self.setData(title, data)
-
-    def modifyWidget(self, title, **kwargs):
-        """title = (str) the corresponding widget name.
-        kwargs = args corresponding to the get_<arg> methods of the wdg-class.
-        """
-        log.warn('The \'modifyWidget()\' function is deprecated, use \'setAttr()\' instead.  '+str(self.node.getFullPath()))
-        self.setAttr(title, **kwargs)
-
-    def getEvent(self):
-        '''Allow node developer to get information about what event has caused
-        the node to run.'''
-        log.warn('The \'getEvent()\' function is deprecated, use \'getEvents()\' (its the plural form). '+str(self.node.getFullPath()))
-        return self.node.getPendingEvent()
-
-    def portEvent(self):
-        '''Specifically check for a port event.'''
-        log.warn('The \'portEvent()\' function is deprecated, use \'portEvents()\' (its the plural form). '+str(self.node.getFullPath()))
-        if GPI_PORT_EVENT in self.getEvent():
-            return self.getEvent()[GPI_PORT_EVENT]
-        return None
-
-    def widgetEvent(self):
-        '''Specifically check for a wdg event.'''
-        log.warn('The \'widgetEvent()\' function is deprecated, use \'widgetEvents()\' (its the plural form). '+str(self.node.getFullPath()))
-        if GPI_WIDGET_EVENT in self.getEvent():
-            return self.getEvent()[GPI_WIDGET_EVENT]
-        return None
-############### DEPRECATED NODE API
-
-    def getEvents(self):
-        '''Allow node developer to get information about what event has caused
-        the node to run.'''
-        return self.node.getPendingEvents().events
-
-    def portEvents(self):
-        '''Specifically check for a port event.  Widget-ports count as both.'''
-        return self.node.getPendingEvents().port
-
-    def widgetEvents(self):
-        '''Specifically check for a wdg event.'''
-        return self.node.getPendingEvents().widget
-
-    def widgetMovingEvent(self, wdgid):
-        '''Called when a widget drag is being initiated.
-        '''
-        pass
 
     def getWidgetByID(self, wdgID):
         for parm in self.parmList:

--- a/lib/gpi/nodeUI.py
+++ b/lib/gpi/nodeUI.py
@@ -123,6 +123,12 @@ class NodeUI(QtGui.QWidget):
         for parm in self.parmList:
             parm.setDispTitle()
 
+        for title, params in inPorts.items():
+            self.addInPort(title=title, **params)
+
+        for title, params in outPorts.items():
+            self.addOutPort(title=title, **params)
+
         # make a label box with the unique id
         labelGroup = HidableGroupBox("Node Label")
         labelLayout = QtGui.QGridLayout()
@@ -210,19 +216,6 @@ class NodeUI(QtGui.QWidget):
         # return GPI_THREAD
         return GPI_PROCESS  # this is the safest
         # return GPI_APPLOOP
-
-    def setReQueue(self, val=False):  # NODEAPI
-        # At the end of a nodeQueue, these tasked are checked for
-        # more events.
-        if self.node.inDisabledState():
-            return
-        if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
-            self.node.nodeCompute_thread.addToQueue(['setReQueue', val])
-        else:
-            self.node._requeue = val
-
-    def reQueueIsSet(self):
-        return self.node._requeue
 
     def getLabel(self):
         return self._label
@@ -797,6 +790,7 @@ class NodeUI(QtGui.QWidget):
         except:
             raise GPIError_nodeAPI_getData('self.getData(\''+stw(title)+'\') failed in the node definition check the port name.')
 
+    # TODO: deprecate these?
     def getInPort(self, pnumORtitle):
         return self.node.getInPort(pnumORtitle)
 

--- a/lib/gpi/nodeUI.py
+++ b/lib/gpi/nodeUI.py
@@ -1,0 +1,793 @@
+#    Copyright (C) 2014  Dignity Health
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Lesser General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#    NO CLINICAL USE.  THE SOFTWARE IS NOT INTENDED FOR COMMERCIAL PURPOSES
+#    AND SHOULD BE USED ONLY FOR NON-COMMERCIAL RESEARCH PURPOSES.  THE
+#    SOFTWARE MAY NOT IN ANY EVENT BE USED FOR ANY CLINICAL OR DIAGNOSTIC
+#    PURPOSES.  YOU ACKNOWLEDGE AND AGREE THAT THE SOFTWARE IS NOT INTENDED FOR
+#    USE IN ANY HIGH RISK OR STRICT LIABILITY ACTIVITY, INCLUDING BUT NOT
+#    LIMITED TO LIFE SUPPORT OR EMERGENCY MEDICAL OPERATIONS OR USES.  LICENSOR
+#    MAKES NO WARRANTY AND HAS NOR LIABILITY ARISING FROM ANY USE OF THE
+#    SOFTWARE IN ANY HIGH RISK OR STRICT LIABILITY ACTIVITIES.
+
+
+import os
+import imp
+import time
+import copy
+import hashlib
+import inspect
+import traceback
+from multiprocessing import sharedctypes # numpy xfer
+
+# gpi
+import gpi
+from gpi import QtCore, QtGui
+from .defines import ExternalNodeType, GPI_PROCESS, GPI_THREAD, stw, GPI_SHDM_PATH
+from .defines import GPI_WIDGET_EVENT, REQUIRED, OPTIONAL, GPI_PORT_EVENT
+from .dataproxy import DataProxy, ProxyType
+from .logger import manager
+from .port import InPort, OutPort
+from .widgets import HidableGroupBox
+from . import widgets as BUILTIN_WIDGETS
+from . import syntax
+
+
+# start logger for this module
+log = manager.getLogger(__name__)
+
+# for PROCESS data hack
+import numpy as np
+
+# Developer Interface Exceptions
+class GPIError_nodeAPI_setData(Exception):
+    def __init__(self, value):
+        super(GPIError_nodeAPI_setData, self).__init__(value)
+
+class GPIError_nodeAPI_getData(Exception):
+    def __init__(self, value):
+        super(GPIError_nodeAPI_getData, self).__init__(value)
+
+class GPIError_nodeAPI_setAttr(Exception):
+    def __init__(self, value):
+        super(GPIError_nodeAPI_setAttr, self).__init__(value)
+
+class GPIError_nodeAPI_getAttr(Exception):
+    def __init__(self, value):
+        super(GPIError_nodeAPI_getAttr, self).__init__(value)
+
+class GPIError_nodeAPI_getVal(Exception):
+    def __init__(self, value):
+        super(GPIError_nodeAPI_getVal, self).__init__(value)
+
+
+class NodeUI(QtGui.QWidget):
+    """This is the class that manages the UI corresponding to the node
+    definition (some implementiation inheriting from NodeAPI)."""
+
+    modifyWdg = gpi.Signal(str, dict)
+
+    def __init__(self, node):
+        # grid for module widgets
+        self.layout = QtGui.QGridLayout()
+
+        # this must exist before user-widgets are added so that they can get
+        # node label updates
+        self.wdglabel = QtGui.QLineEdit(self.label)
+
+        # make a label box with the unique id
+        labelGroup = HidableGroupBox("Node Label")
+        labelLayout = QtGui.QGridLayout()
+        self.wdglabel.textChanged.connect(self.setLabel)
+        labelLayout.addWidget(self.wdglabel, 0, 1)
+        labelGroup.setLayout(labelLayout)
+        self.layout.addWidget(labelGroup, len(self.parmList) + 1, 0)
+        labelGroup.set_collapsed(True)
+        labelGroup.setToolTip("Displays the Label on the Canvas (Double Click)")
+
+        # make an about button that will pop up the node documentation
+        self.aboutGroup = HidableGroupBox("About")
+        aboutLayout = QtGui.QGridLayout()
+        self.about_button = QtGui.QPushButton("Open Node &Documentation")
+        self.about_button.clicked.connect(self.openNodeDocumentation)
+        aboutLayout.addWidget(self.about_button, 0, 1)
+        self.aboutGroup.setLayout(aboutLayout)
+        self.layout.addWidget(self.aboutGroup, len(self.parmList) + 2, 0)
+        self.aboutGroup.set_collapsed(True)
+        self.aboutGroup.setToolTip("Node Documentation (docstring + autodocs, Double Click)")
+
+        # window (just a QTextEdit) that will show documentation text
+        self.doc_text_win = QtGui.QTextEdit()
+        self.doc_text_win.setPlainText(self.generateHelpText())
+        self.doc_text_win.setReadOnly(True)
+        doc_text_font = QtGui.QFont("Monospace", 14)
+        self.doc_text_win.setFont(doc_text_font)
+        self.doc_text_win.setLineWrapMode(QtGui.QTextEdit.NoWrap)
+        self.doc_text_win.setWindowTitle(node.getModuleName() + " Documentation")
+
+        hbox = QtGui.QHBoxLayout()
+        self._statusbar_sys = QtGui.QLabel('')
+        self._statusbar_usr = QtGui.QLabel('')
+        hbox.addWidget(self._statusbar_sys)
+        hbox.addWidget(self._statusbar_usr, 0, (QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter))
+
+        # window resize grip
+        self._grip = QtGui.QSizeGrip(self)
+        hbox.addWidget(self._grip)
+
+        self.layout.addLayout(hbox, len(self.parmList) + 3, 0)
+        self.layout.setRowStretch(len(self.parmList) + 3, 0)
+
+        # instantiate the layout
+        self.setLayout(self.layout)
+
+        self.setTitle(node.getModuleName())
+
+        self._initUI(node)
+
+        self._starttime = 0
+        self._startline = 0
+
+    def setStatus_sys(self, msg):
+        msg += self.stringifyExecType()
+        self._statusbar_sys.setText(msg)
+
+    def setStatus(self, msg):
+        self._statusbar_usr.setText(msg)
+
+    def moduleExists(self, name):
+        '''Give the user a simple module checker for the node validate
+        function.
+        '''
+        try:
+            imp.find_module(name)
+        except ImportError:
+            return False
+        else:
+            return True
+
+    def moduleValidated(self, name):
+        '''Provide a stock error message in the event a c/ext module cannot
+        be found.
+        '''
+        if not self.moduleExists(name):
+            log.error("The \'" + name + "\' module cannot be found, compute() aborted.")
+            return 1
+        return 0
+
+    def openNodeDocumentation(self):
+        self.doc_text_win.show()
+
+        # setting the size only works if we have shown the widget
+        # set the width based on some ideal width (max at 800px)
+        docwidth = self.doc_text_win.document().idealWidth()
+        lmargin = self.doc_text_win.contentsMargins().left()
+        rmargin = self.doc_text_win.contentsMargins().right()
+        scrollbar_width = 20 # estimate, scrollbar overlaps content otherwise
+        total_width = min(lmargin + docwidth + rmargin + scrollbar_width, 800)
+        self.doc_text_win.setFixedWidth(total_width)
+
+        # set the height based on the content size
+        docheight= self.doc_text_win.document().size().height()
+        self.doc_text_win.setMinimumHeight(min(docheight, 200))
+        self.doc_text_win.setMaximumHeight(docheight)
+
+    def setDetailLabel(self, newDetailLabel='', elideMode='middle'):
+        '''An additional label displayed on the node directly'''
+        self._detailLabel = str(newDetailLabel)
+        self._detailElideMode = elideMode
+        self.node.updateOutportPosition()
+
+    def getDetailLabel(self):
+        '''An additional label displayed on the node directly'''
+        return self._detailLabel
+
+    def getDetailLabelElideMode(self):
+        '''How the detail label should be elided if it's too long:'''
+        mode = self._detailElideMode
+        qt_mode = QtCore.Qt.ElideMiddle
+        if mode == 'left':
+            qt_mode = QtCore.Qt.ElideLeft
+        elif mode == 'right':
+            qt_mode = QtCore.Qt.ElideRight
+        elif mode == 'none':
+            qt_mode = QtCore.Qt.ElideNone
+        else: # default, mode == 'middle'
+            qt_mode = QtCore.Qt.ElideMiddle
+
+        return qt_mode
+
+    def windowActivationChange(self, test):
+        self.node.graph.scene().makeOnlyTheseNodesSelected([self.node])
+
+    def getSettings(self):  # NODEAPI
+        '''Wrap up all settings from each widget.'''
+        s = {}
+        s['label'] = self.label
+        s['parms'] = []
+        for parm in self.parmList:
+            s['parms'].append(copy.deepcopy(parm.getSettings()))
+        return s
+
+    def loadSettings(self, s):
+        self.setLabelWidget(s['label'])
+
+        # modify node widgets
+        for parm in s['parms']:
+            # the NodeAPI has instantiated the widget by name, this will
+            # change the wdg-ID, however, this step is only dependend on
+            # unique widget names.
+
+            if not self.getWidget(parm['name']):
+                log.warn("Trying to load settings; can't find widget with name: \'" + \
+                    stw(parm['name']) + "\', skipping...")
+                continue
+
+            log.debug('Setting widget: \'' + stw(parm['name']) + '\'')
+            try:
+                self.modifyWidget_direct(parm['name'], **parm['kwargs'])
+            except:
+                log.error('Failed to set widget: \'' + stw(parm['name']) + '\'\n' + str(traceback.format_exc()))
+
+            if parm['kwargs']['inport']:  # widget-inports
+                self.addWidgetInPortByName(parm['name'])
+            if parm['kwargs']['outport']:  # widget-outports
+                self.addWidgetOutPortByName(parm['name'])
+
+
+    def generateHelpText(self):
+        """Gather the __doc__ string of the ExternalNode derived class,
+        all the set_ methods for each attached widget, and any attached
+        GPI-types from each of the ports.
+        """
+        if self._docText is not None:
+            return self._docText
+
+        # NODE DOC
+        node_doc = "NODE: \'" + self.node._moduleName + "\'\n" + "    " + \
+            str(self.__doc__)
+
+        # WIDGETS DOC
+        # parm_doc = ""  # contains parameter info
+        wdg_doc = "\n\nAPPENDIX A: (WIDGETS)\n"  # generic widget ref info
+        for parm in self.parmList:  # wdg order matters
+            wdg_doc += "\n  \'" + parm.getTitle() + "\': " + \
+                str(parm.__class__) + "\n"
+            numSpaces = 8
+            set_doc = "\n".join((numSpaces * " ") + i for i in str(
+                parm.__doc__).splitlines())
+            wdg_doc += set_doc + "\n"
+            # set methods
+            for member in dir(parm):
+                if member.startswith('set_'):
+                    wdg_doc += (8 * " ") + member + inspect.formatargspec(
+                        *inspect.getargspec(getattr(parm, member)))
+                    set_doc = str(inspect.getdoc(getattr(parm, member)))
+                    numSpaces = 16
+                    set_doc = "\n".join((
+                        numSpaces * " ") + i for i in set_doc.splitlines())
+                    wdg_doc += "\n" + set_doc + "\n"
+
+        # PORTS DOC
+        port_doc = "\n\nAPPENDIX B: (PORTS)\n"  # get the port type info
+        for port in self.node.getPorts():
+            typ = port.GPIType()
+            port_doc += "\n  \'" + port.portTitle + "\': " + \
+                str(typ.__class__) + "|" + str(type(port)) + "\n"
+            numSpaces = 8
+            set_doc = "\n".join((numSpaces * " ") + i for i in str(
+                typ.__doc__).splitlines())
+            port_doc += set_doc + "\n"
+
+            # set methods
+            for member in dir(typ):
+                if member.startswith('set_'):
+                    port_doc += (8 * " ") + member + inspect.formatargspec(
+                        *inspect.getargspec(getattr(typ, member)))
+                    set_doc = str(inspect.getdoc(getattr(typ, member)))
+                    numSpaces = 16
+                    set_doc = "\n".join((
+                        numSpaces * " ") + i for i in set_doc.splitlines())
+                    port_doc += "\n" + set_doc + "\n"
+
+        # GETTERS/SETTERS
+        getset_doc = "\n\nAPPENDIX C: (GETTERS/SETTERS)\n\n"
+        getset_doc += (8 * " ") + "Node Initialization Setters: (initUI())\n\n"
+        getset_doc += self.formatFuncDoc(self.addWidget)
+        getset_doc += self.formatFuncDoc(self.addInPort)
+        getset_doc += self.formatFuncDoc(self.addOutPort)
+        getset_doc += (
+            8 * " ") + "Node Compute Getters/Setters: (compute())\n\n"
+        getset_doc += self.formatFuncDoc(self.getVal)
+        getset_doc += self.formatFuncDoc(self.getAttr)
+        getset_doc += self.formatFuncDoc(self.setAttr)
+        getset_doc += self.formatFuncDoc(self.getData)
+        getset_doc += self.formatFuncDoc(self.setData)
+
+        self._docText = node_doc  # + wdg_doc + port_doc + getset_doc
+
+        self.doc_text_win.setPlainText(self._docText)
+
+        return self._docText
+
+    def formatFuncDoc(self, func):
+        """Generate auto-doc for passed func obj."""
+        numSpaces = 24
+        fdoc = inspect.getdoc(func)
+        set_doc = "\n".join((
+            numSpaces * " ") + i for i in str(fdoc).splitlines())
+        rdoc = (16 * " ") + func.__name__ + \
+            inspect.formatargspec(*inspect.getargspec(func)) \
+            + "\n" + set_doc + "\n\n"
+        return rdoc
+
+    def printWidgetValues(self):
+        # for debugging
+        for parm in self.parmList:
+            log.debug("widget: " + str(parm))
+            log.debug("value: " + str(parm.get_val()))
+
+    def addWidget(self, wdg=None, title=None, **kwargs):
+        """wdg = (str) corresponds to the widget class name
+        title = (str) is the string label given in the node-menu
+        kwargs = corresponds to the set_<arg> methods specific
+                    to the chosen wdg-class.
+        """
+
+        if (wdg is None) or (title is None):
+            log.critical("addWidget(): widgets need a title" \
+                + " AND a wdg-str! Aborting.")
+            return
+
+        # check existence first
+        if self.node.titleExists(title):
+            log.critical("addWidget(): Widget title \'" + str(title) \
+                + "\' is already in use! Aborting.")
+            return
+
+        ypos = len(self.parmList)
+
+        # try widget def's packaged with node def first
+        wdgGroup = None
+
+        # first see if the node code contains the widget def
+        wdgGroup = self.node.item.getWidget(wdg)
+
+        # get widget from standard gpi widgets
+        if wdgGroup is None:
+            if hasattr(BUILTIN_WIDGETS, wdg):
+                wdgGroup = getattr(BUILTIN_WIDGETS, wdg)
+
+        # if its still not found then its a big deal
+        if wdgGroup is None:
+            log.critical("\'" + wdg + "\' widget not found.")
+            raise Exception("Widget not found.")
+
+        # instantiate if not None
+        else:
+            wdgGroup = wdgGroup(title)
+
+        wdgGroup.setNodeName(self.node.getModuleName())
+        wdgGroup._setNodeLabel(self.label)
+
+        wdgGroup.valueChanged.connect(lambda: self.wdgEvent(title))
+        wdgGroup.portStateChange.connect(lambda: self.changePortStatus(title))
+        wdgGroup.returnWidgetToOrigin.connect(self.returnWidgetToNodeMenu)
+        self.wdglabel.textChanged.connect(wdgGroup._setNodeLabel)
+
+        # add to menu layout
+        self.layout.addWidget(wdgGroup, ypos, 0)
+        self.parmList.append(wdgGroup)
+        self.parmDict[title] = wdgGroup  # the new way
+
+        self.modifyWidget_direct(title, **kwargs)
+
+    def returnWidgetToNodeMenu(self, wdgid):
+        # find widget by id
+        wdgid = int(wdgid)
+        ind = 0
+        for parm in self.parmList:
+            if wdgid == parm.get_id():
+                self.layout.addWidget(parm, ind, 0)
+                if self.node.isMarkedForDeletion():
+                    parm.hide()
+                else:
+                    parm.show()
+                break
+            ind += 1
+
+    def blockWdgSignals(self, val):
+        '''Block all signals, especially valueChanged.'''
+        for parm in self.parmList:
+            parm.blockSignals(val)
+
+    def blockSignals_byWdg(self, title, val):
+        # get the over-reporting widget by name and block it
+        self.parmDict[title].blockSignals(val)
+
+    def changePortStatus(self, title):
+        '''Add a new in- or out-port tied to this widget.'''
+        log.debug("changePortStatus: " + str(title))
+        wdg = self.findWidgetByName(title)
+
+        # make sure the port is either added or will be added.
+        if wdg.inPort_ON:
+            if self.findWidgetInPortByName(title) is None:
+                self.addWidgetInPort(wdg)
+        else:
+            if self.findWidgetInPortByName(title):
+                self.removeWidgetInPort(wdg)
+        if wdg.outPort_ON:
+            if self.findWidgetOutPortByName(title) is None:
+                self.addWidgetOutPort(wdg)
+        else:
+            if self.findWidgetOutPortByName(title):
+                self.removeWidgetOutPort(wdg)
+
+    def findWidgetByName(self, title):
+        for parm in self.parmList:
+            if parm.getTitle() == title:
+                return parm
+
+    def findWidgetByID(self, wdgID):
+        for parm in self.parmList:
+            if parm.id() == wdgID:
+                return parm
+
+    def findWidgetInPortByName(self, title):
+        for port in self.node.inportList:
+            if port.isWidgetPort():
+                if port.portTitle == title:
+                    return port
+
+    def findWidgetOutPortByName(self, title):
+        for port in self.node.outportList:
+            if port.isWidgetPort():
+                if port.portTitle == title:
+                    return port
+
+    def modifyWidget_setter(self, src, kw, val):
+        sfunc = "set_" + kw
+        if hasattr(src, sfunc):
+            func = getattr(src, sfunc)
+            func(val)
+        else:
+            try:
+                ttl = src.getTitle()
+            except:
+                ttl = str(src)
+
+            log.critical("modifyWidget_setter(): Widget \'" + stw(ttl) \
+                + "\' doesn't have attr \'" + stw(sfunc) + "\'.")
+
+    def modifyWidget_direct(self, pnumORtitle, **kwargs):
+        src = self.getWidget(pnumORtitle)
+
+        for k, v in list(kwargs.items()):
+            if k != 'val':
+                self.modifyWidget_setter(src, k, v)
+
+        # set 'val' last so that bounds don't cause a temporary conflict.
+        if 'val' in kwargs:
+            self.modifyWidget_setter(src, 'val', kwargs['val'])
+
+    def modifyWidget_buffer(self, title, **kwargs):
+        '''GPI_PROCESSes have to use buffered widget attributes to effect the
+        same changes to attributes during compute() as with GPI_THREAD or
+        GPI_APPLOOP.
+        '''
+        src = self.getWdgFromBuffer(title)
+
+        try:
+            for k, v in list(kwargs.items()):
+                src['kwargs'][k] = v
+        except:
+            log.critical("modifyWidget_buffer() FAILED to modify buffered attribute")
+
+
+    def lockWidgetUpdates(self):
+        self._widgetUpdateMutex_locked = True
+
+    def unlockWidgetUpdates(self):
+        self._widgetUpdateMutex_locked = False
+
+    def widgetsUpdatesLocked(self):
+        return self._widgetUpdateMutex_locked
+
+    def wdgEvent(self, title):
+        # Captures all valueChanged events from widgets.
+        # 'title' is for interrogating who changed in compute().
+
+        # Once the event status has been set, disable valueChanged signals
+        # until the node has successfully completed.
+        # -this was b/c sliders etc. were causing too many signals resulting
+        # in a recursion overload to this function.
+        #self.blockWdgSignals(True)
+        self.blockSignals_byWdg(title, True)
+
+        if self.node.hasEventPending():
+            self.node.appendEvent({GPI_WIDGET_EVENT: title})
+            return
+        else:
+            self.node.setEventStatus({GPI_WIDGET_EVENT: title})
+
+        # Can start event from any applicable 'check' transition
+        if self.node.graph.inIdleState():
+            self.node.graph._switchSig.emit('check')
+
+    # for re-drawing the menu title to match module/node instance
+    def updateTitle(self):
+        # Why is this trying the scrollArea? isn't it always a scroll???
+        if self.label == '':
+            try:
+                self.node._nodeIF_scrollArea.setWindowTitle(self.node.name)
+            except:
+                self.setWindowTitle(self.node.name)
+        else:
+            try:
+                augtitle = self.node.name + ": " + self.label
+                self.node._nodeIF_scrollArea.setWindowTitle(augtitle)
+            except:
+                augtitle = self.node.name + ": " + self.label
+                self.setWindowTitle(augtitle)
+
+    def setTitle(self, title):
+        self.node.name = title
+        self.updateTitle()
+
+    # Queue actions for widgets and ports
+    def setAttr(self, title, **kwargs):
+        """title = (str) the corresponding widget name.
+        kwargs = args corresponding to the get_<arg> methods of the wdg-class.
+        """
+        try:
+            # start = time.time()
+            # either emit a signal or save a queue
+            if self.node.inDisabledState():
+                return
+            if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
+                # PROCESS
+                self.node.nodeCompute_thread.addToQueue(['modifyWdg', title, kwargs])
+                #self.modifyWidget_buffer(title, **kwargs)
+            elif self.node.nodeCompute_thread.execType() == GPI_THREAD:
+                # THREAD
+                # can't modify QObjects in thread, but we can send a signal to do
+                # so
+                self.modifyWdg.emit(title, kwargs)
+            else:
+                # APPLOOP
+                self.modifyWidget_direct(str(title), **kwargs)
+
+        except:
+            raise GPIError_nodeAPI_setAttr('self.setAttr(\''+stw(title)+'\',...) failed in the node definition, check the widget name, attribute name and attribute type().')
+
+        # log.debug("modifyWdg(): time: "+str(time.time() - start)+" sec")
+
+    def allocArray(self, shape=(1,), dtype=np.float32, name='local'):
+        '''return a shared memory array if the node is run as a process.
+            -the array name needs to be unique
+        '''
+        if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
+            buf, shd = DataProxy()._genNDArrayMemmap(shape, dtype, self.node.getID(), name)
+
+            if shd is not None:
+                # saving the reference id allows the node developer to decide
+                # on the fly if the preallocated array will be used in the final
+                # setData() call.
+                self.shdmDict[str(id(buf))] = shd.filename
+
+            return buf
+        else:
+            return np.ndarray(shape, dtype=dtype)
+
+    def setData(self, title, data):
+        """title = (str) name of the OutPort to send the object reference.
+        data = (object) any object corresponding to a GPIType class.
+        """
+        try:
+            # start = time.time()
+            # either set directly or save a queue
+            if self.node.inDisabledState():
+                return
+            if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
+
+                #  numpy arrays
+                if type(data) is np.memmap or type(data) is np.ndarray:
+                    if str(id(data)) in self.shdmDict: # pre-alloc
+                        s = DataProxy().NDArray(data, shdf=self.shdmDict[str(id(data))], nodeID=self.node.getID(), portname=title)
+                    else:
+                        s = DataProxy().NDArray(data, nodeID=self.node.getID(), portname=title)
+
+                    # for split objects to pass thru individually
+                    # this will be a list of DataProxy objects
+                    if type(s) is list:
+                        for i in s:
+                            self.node.nodeCompute_thread.addToQueue(['setData', title, i])
+                    # a single DataProxy object
+                    else:
+                        self.node.nodeCompute_thread.addToQueue(['setData', title, s])
+
+                # all other non-numpy data that are pickleable
+                else:
+                    # PROCESS output other than numpy
+                    self.node.nodeCompute_thread.addToQueue(['setData', title, data])
+            else:
+                # THREAD or APPLOOP
+                self.node.setData(title, data)
+                # log.debug("setData(): time: "+str(time.time() - start)+" sec")
+
+        except:
+            print((str(traceback.format_exc())))
+            raise GPIError_nodeAPI_setData('self.setData(\''+stw(title)+'\',...) failed in the node definition, check the output name and data type().')
+
+    def getData(self, title):
+        """title = (str) the name of the InPort.
+        """
+        try:
+            port = self.node.getPortByNumOrTitle(title)
+            if isinstance(port, InPort):
+                data = port.getUpstreamData()
+                if type(data) is np.ndarray:
+                    # don't allow users to change original array attributes
+                    # that aren't protected by the 'writeable' flag
+                    buf = np.frombuffer(data.data, dtype=data.dtype)
+                    buf.shape = tuple(data.shape)
+                    return buf
+                else:
+                    return data
+
+            elif isinstance(port, OutPort):
+                return port.data
+            else:
+                raise Exception("getData", "Invalid Port Title")
+        except:
+            raise GPIError_nodeAPI_getData('self.getData(\''+stw(title)+'\') failed in the node definition check the port name.')
+
+    def getInPort(self, pnumORtitle):
+        return self.node.getInPort(pnumORtitle)
+
+    def getOutPort(self, pnumORtitle):
+        return self.node.getOutPort(pnumORtitle)
+
+    def getEvents(self):
+        '''Allow node developer to get information about what event has caused
+        the node to run.'''
+        return self.node.getPendingEvents().events
+
+    def portEvents(self):
+        '''Specifically check for a port event.  Widget-ports count as both.'''
+        return self.node.getPendingEvents().port
+
+    def widgetEvents(self):
+        '''Specifically check for a wdg event.'''
+        return self.node.getPendingEvents().widget
+
+    def widgetMovingEvent(self, wdgid):
+        '''Called when a widget drag is being initiated.
+        '''
+        pass
+
+    def getWidgetByID(self, wdgID):
+        for parm in self.parmList:
+            if parm.id() == wdgID:
+                return parm
+        log.critical("getWidgetByID(): Cannot find widget id:" + str(wdgID))
+
+    def getWidget(self, pnum):
+        '''Returns the widget desc handle and position number'''
+        # fetch by widget number
+        if type(pnum) is int:
+            if (pnum < 0) or (pnum >= len(self.parmList)):
+                log.error("getWidget(): Target widget out of range: " + str(pnum))
+                return
+            src = self.parmList[pnum]
+        # fetch by widget title
+        elif type(pnum) is str:
+            src = None
+            cnt = 0
+            for parm in self.parmList:
+                if parm.getTitle() == pnum:
+                    src = parm
+                    pnum = cnt  # change pnum back to int
+                cnt += 1
+            if src is None:
+                log.error("getWidget(): Failed to find widget: \'" + stw(pnum) + "\'")
+                return
+        else:
+            log.error("getWidget(): Widget identifier must be" + " either int or str")
+            return
+        return src
+
+    def bufferParmSettings(self):
+        '''Get list of parms (dict) in self.parmSettings['parms'].
+        Called by GPI_PROCESS functor to capture all widget settings needed
+        in compute().
+        '''
+        self.parmSettings = self.getSettings()
+
+    def getWdgFromBuffer(self, title):
+        # find a specific widget by title
+        for wdg in self.parmSettings['parms']:
+            if 'name' in wdg:
+                if wdg['name'] == title:
+                    return wdg
+
+
+    def getVal(self, title):
+        """Returns get_val() from wdg-class (see getAttr()).
+        """
+        try:
+            # Fetch widget value by title
+            if self.node.inDisabledState():
+                return
+
+            if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
+                return self.getAttr(title, 'val')
+
+            # threads and main loop can access directly
+            return self.getAttr(title, 'val')
+
+        except:
+            print(str(traceback.format_exc()))
+            raise GPIError_nodeAPI_getVal('self.getVal(\''+stw(title)+'\') failed in the node definition, check the widget name.')
+
+    def getAttr(self, title, attr):
+        """title = (str) wdg-class name
+        attr = (str) corresponds to the get_<arg> of the desired attribute.
+        """
+        try:
+            # Fetch widget value by title
+            if self.node.inDisabledState():
+                return
+
+            if self.node.nodeCompute_thread.execType() == GPI_PROCESS:
+                wdg = self.getWdgFromBuffer(title)
+                return self._getAttr_fromWdg(wdg, attr)
+
+            # threads and main loop can access directly
+            wdg = self.getWidget(title)
+            return self._getAttr_fromWdg(wdg, attr)
+
+        except:
+            print(str(traceback.format_exc()))
+            raise GPIError_nodeAPI_getAttr('self.getAttr(\''+stw(title)+'\',...) failed in the node definition, check widget name and attribute name.')
+
+    def _getAttr_fromWdg(self, wdg, attr):
+        try:
+            # input is either a dict or a wdg instance.
+            if isinstance(wdg, dict):  # buffered values
+                if attr in wdg['kwargs']:
+                    return wdg['kwargs'][attr]
+                else:
+                    # build error msg
+                    title = wdg['name']
+                    funame = attr
+            else:  # direct widget access
+                funame = 'get_' + attr
+                if hasattr(wdg, funame):
+                    return getattr(wdg, funame)()
+                else:
+                    try:
+                        title = wdg.getTitle()
+                    except:
+                        title = "\'no name\'"
+            log.critical("_getAttr(): widget \'" + stw(title) + "\' has no attr \'" + stw(funame) + "\'.")
+            #return None
+            raise GPIError_nodeAPI_getAttr('_getAttr() failed for widget \''+stw(title)+'\'')
+        except:
+            #log.critical("_getAttr_fromWdg(): Likely the wrong input arg type.")
+            #raise
+            print(str(traceback.format_exc()))
+            raise GPIError_nodeAPI_getAttr('_getAttr() failed for widget \''+stw(title)+'\'')

--- a/lib/gpi/nodeUI.py
+++ b/lib/gpi/nodeUI.py
@@ -617,7 +617,7 @@ class NodeUI(QtGui.QWidget):
         src = self.getWidget(pnumORtitle)
 
         for k, v in kwargs.items():
-            if k != 'val':
+            if k not in ('val', 'wdg'):
                 self.modifyWidget_setter(src, k, v)
 
         # set 'val' last so that bounds don't cause a temporary conflict.
@@ -918,8 +918,11 @@ class NodeUI(QtGui.QWidget):
             print(str(traceback.format_exc()))
             raise GPIError_nodeAPI_getAttr('_getAttr() failed for widget \''+stw(title)+'\'')
 
-    def post_compute_widget_update(self):
+    def post_compute_widget_update(self, widgets):
         # reset any widget that requires it (i.e. PushButton)
         for parm in self.getParmList():
             if hasattr(parm, 'set_reset'):
                 parm.set_reset()
+        for widget_title, parms in self._parmDict.items():
+            self.modifyWidget_direct(widget_title, **widgets[widget_title])
+

--- a/lib/gpi/nodeUI.py
+++ b/lib/gpi/nodeUI.py
@@ -182,7 +182,11 @@ class NodeUI(QtGui.QWidget):
 
     def getWidgets(self):
         # return a list of widgets
-        return self.parmList
+        widgets = {}
+        for widget in self.parmList:
+            widgets[widget.title()] = {'wdg' : widget.__class__.__name__}
+            widgets[widget.title()].update(**widget.getSettings()['kwargs'])
+        return widgets
 
     def getWidgetNames(self):
         return list(self.parmDict.keys())

--- a/lib/gpi/widgets.py
+++ b/lib/gpi/widgets.py
@@ -890,7 +890,7 @@ class GenericWidgetGroup(QtGui.QGroupBox):
 
     def setDispTitle(self):
         # if its the node menu then reset title
-        if hasattr(self.parent(), 'GPIExtNodeType'):
+        if hasattr(self.parent(), 'NodeUIType'):
             self.setTitle(self._title)
         else:
             if self._nodelabel == '':


### PR DESCRIPTION
This branch is an attempt to separate the node interface from computation. Much progress was made, but _this refactor is dormant_, but may serve as a useful proof-of-concept to future developers.

Motivation for this project was:
1) Enable use of multiprocessing on Windows using the ForkServer (introduced in Python 3). This could not be done using the existing framework, because Python requires all objects for multiprocessing to be pickle-able (bound methods are not).
2) Make it easier to implement a self-testing structure for nodes.
3) Enable a future transition to a client-server structure for the framework; running remote nodes, node parallelism, new interfaces, etc.