### PR TITLE
Handle PATH requirements for GPI launched outside of an active conda environment

### DIFF
--- a/launch/gpi.command
+++ b/launch/gpi.command
@@ -35,8 +35,11 @@ fi
 ANACONDA=/opt/anaconda1anaconda2anaconda3
 PYTHON=${ANACONDA}/bin/python
 GPI_LAUNCH=${ANACONDA}/bin/gpi_launch
-WIN_PYTHON=${ANACONDA}/python
-WIN_GPI_LAUNCH=${ANACONDA}/Scripts/gpi_launch
+
+BINDIR="$ANACONDA/bin"
+if ! echo $PATH | grep -q $BINDIR ; then
+  PATH="${BINDIR}:${PATH}"
+fi
 
 GPI_LINK=/tmp/GPI
 
@@ -49,7 +52,7 @@ elif [ "$(uname)" == "Linux" ]; then
     $PYTHON $GPI_LAUNCH -style cleanlooks $@
 # Windows
 else
-    $WIN_PYTHON -u $WIN_GPI_LAUNCH -style Windows $@
+    python -u gpi_launch -style Windows $@
 fi
 
 

--- a/launch/gpi_cmd.bat
+++ b/launch/gpi_cmd.bat
@@ -1,5 +1,5 @@
 @echo off
-
+setlocal
 ::    Copyright (C) 2014  Dignity Health
 ::
 ::    This program is free software: you can redistribute it and/or modify
@@ -24,15 +24,26 @@
 ::    MAKES NO WARRANTY AND HAS NO LIABILITY ARISING FROM ANY USE OF THE
 ::    SOFTWARE IN ANY HIGH RISK OR STRICT LIABILITY ACTIVITIES.
 
-:: The GPI launcher script.  The .command suffix is used by OSX open.
-
-:: get user environment settings
-::   -this will pickup the user's visual editor
+:: The GPI launcher script for Windows installations.
 
 set ANACONDA=/opt/anaconda1anaconda2anaconda3
 set PYTHON=%ANACONDA%\python
 set GPI_LAUNCH=%ANACONDA%\Scripts\gpi_launch
 
-%PYTHON% %GPI_LAUNCH% -style Windows %*
+:: Add needed folders to the path if launching from outside an active conda
+set ANACONDA_WIN=%ANACONDA:/=\%
+echo %PATH% | findstr %ANACONDA_WIN% > NUL
+if %ERRORLEVEL% NEQ 0 goto :fixpath
+goto :endif
 
+:fixpath
+  set PATH=%ANACONDA_WIN%\bin;%PATH%
+  set PATH=%ANACONDA_WIN%\Scripts;%PATH%
+  set PATH=%ANACONDA_WIN%\Library\bin;%PATH%
+  set PATH=%ANACONDA_WIN%\Library\usr\bin;%PATH%
+  set PATH=%ANACONDA_WIN%\Library\mingw-w64\bin;%PATH%
+  set PATH=%ANACONDA_WIN%;%PATH%
+:endif
+
+%PYTHON% %GPI_LAUNCH% -style Windows %*
 


### PR DESCRIPTION
This will be a new patch release — it handles PATH requirements when needed (particularly for Windows) so that GPI can be launched as a more traditional application.