### PR TITLE
Restore self-updating behavior

### DIFF
--- a/lib/gpi/update.py
+++ b/lib/gpi/update.py
@@ -46,8 +46,6 @@ if ANACONDA_PREFIX == '/opt/'+'anaconda1anaconda2anaconda3':
     else:
         ANACONDA_PREFIX = os.path.dirname(subprocess.check_output('which conda', shell=True).decode('latin1').strip())
     ANACONDA_PREFIX = os.path.dirname(ANACONDA_PREFIX) # strip off the 'bin'
-else:
-    ANACONDA_PREFIX = os.path.dirname(os.path.dirname(ANACONDA_PREFIX))
 
 class JSONStreamLoads(object):
     ''' Load multiple json objects from string.

--- a/lib/gpi/update.py
+++ b/lib/gpi/update.py
@@ -85,7 +85,7 @@ class CondaUpdater(QtCore.QObject):
         super().__init__()
         self._dry_run = dry_run
         self._conda_prefix = conda_prefix
-        self._packages = ['gpi_core', 'gpi']
+        self._packages = ['gpi', 'gpi_core']
         # DDB - No docs for now on c-f, restore later
         # self._packages = ['gpi', 'gpi_core', 'gpi-docs']
 


### PR DESCRIPTION
This PR restores the "update" functionality for GPI. The only changes required were a few tweaks to handling JSON output from conda and modifying the channel list to search on conda-forge.

I have tested this on all three platforms and it seems to be working. My only outstanding concern is how it will handle cases where a `gpi_core` update is incompatible with the installed `gpi` version. In that case, it's probably better to have `gpi` update first — otherwise, conda will update both when `gpi_core` is updated, and the subsequent `gpi` update may wrongly be interpreted as a failure.