### PR TITLE
Windows bugfixes - node library generator, gpi_make

### DIFF
--- a/launch/GPI.desktop
+++ b/launch/GPI.desktop
@@ -1,3 +1,4 @@
+# No longer in use - deprecate at some point
 [Desktop Entry]
 Version=1.0
 Name=GPI

--- a/launch/gpi.app
+++ b/launch/gpi.app
@@ -24,6 +24,8 @@
 #    MAKES NO WARRANTY AND HAS NO LIABILITY ARISING FROM ANY USE OF THE
 #    SOFTWARE IN ANY HIGH RISK OR STRICT LIABILITY ACTIVITIES.
 
+# No longer in use - deprecate at some point
+
 # The GPI launcher script for the app.
 ANACONDA=/opt/anaconda1anaconda2anaconda3
 # The launcher must point to a script with the ".command" suffix so that 'open'

--- a/launch/gpi.command
+++ b/launch/gpi.command
@@ -36,11 +36,6 @@ ANACONDA=/opt/anaconda1anaconda2anaconda3
 PYTHON=${ANACONDA}/bin/python
 GPI_LAUNCH=${ANACONDA}/bin/gpi_launch
 
-BINDIR="$ANACONDA/bin"
-if ! echo $PATH | grep -q $BINDIR ; then
-  PATH="${BINDIR}:${PATH}"
-fi
-
 GPI_LINK=/tmp/GPI
 
 # OSX

--- a/launch/gpi_cmd.bat
+++ b/launch/gpi_cmd.bat
@@ -30,20 +30,5 @@ set ANACONDA=/opt/anaconda1anaconda2anaconda3
 set PYTHON=%ANACONDA%\python
 set GPI_LAUNCH=%ANACONDA%\Scripts\gpi_launch
 
-:: Add needed folders to the path if launching from outside an active conda
-set ANACONDA_WIN=%ANACONDA:/=\%
-echo %PATH% | findstr %ANACONDA_WIN% > NUL
-if %ERRORLEVEL% NEQ 0 goto :fixpath
-goto :endif
-
-:fixpath
-  set PATH=%ANACONDA_WIN%\bin;%PATH%
-  set PATH=%ANACONDA_WIN%\Scripts;%PATH%
-  set PATH=%ANACONDA_WIN%\Library\bin;%PATH%
-  set PATH=%ANACONDA_WIN%\Library\usr\bin;%PATH%
-  set PATH=%ANACONDA_WIN%\Library\mingw-w64\bin;%PATH%
-  set PATH=%ANACONDA_WIN%;%PATH%
-:endif
-
 %PYTHON% %GPI_LAUNCH% -style Windows %*
 

--- a/launch/gpi_make.cmd
+++ b/launch/gpi_make.cmd
@@ -1,0 +1,34 @@
+@echo off
+setlocal
+::    Copyright (C) 2014  Dignity Health
+::
+::    This program is free software: you can redistribute it and/or modify
+::    it under the terms of the GNU Lesser General Public License as published by
+::    the Free Software Foundation, either version 3 of the License, or
+::    (at your option) any later version.
+::
+::    This program is distributed in the hope that it will be useful,
+::    but WITHOUT ANY WARRANTY; without even the implied warranty of
+::    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+::    GNU Lesser General Public License for more details.
+::
+::    You should have received a copy of the GNU Lesser General Public License
+::    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+::
+::    NO CLINICAL USE.  THE SOFTWARE IS NOT INTENDED FOR COMMERCIAL PURPOSES
+::    AND SHOULD BE USED ONLY FOR NON-COMMERCIAL RESEARCH PURPOSES.  THE
+::    SOFTWARE MAY NOT IN ANY EVENT BE USED FOR ANY CLINICAL OR DIAGNOSTIC
+::    PURPOSES.  YOU ACKNOWLEDGE AND AGREE THAT THE SOFTWARE IS NOT INTENDED FOR
+::    USE IN ANY HIGH RISK OR STRICT LIABILITY ACTIVITY, INCLUDING BUT NOT
+::    LIMITED TO LIFE SUPPORT OR EMERGENCY MEDICAL OPERATIONS OR USES.  LICENSOR
+::    MAKES NO WARRANTY AND HAS NO LIABILITY ARISING FROM ANY USE OF THE
+::    SOFTWARE IN ANY HIGH RISK OR STRICT LIABILITY ACTIVITIES.
+
+:: The GPI make script for Windows installations.
+
+set ANACONDA=/opt/anaconda1anaconda2anaconda3
+set PYTHON=%ANACONDA%\python
+set GPI_MAKE=%ANACONDA%\Scripts\gpi_make
+
+%PYTHON% %GPI_MAKE% %*
+

--- a/lib/gpi/config.py
+++ b/lib/gpi/config.py
@@ -50,10 +50,14 @@ else:
     USER_HOME = os.environ['HOME']
 
 USER_LIB_BASE_PATH_DEFAULT = os.path.join(USER_HOME, 'gpi')
+if Specs.inWindows():
+    userNameKey = 'USERNAME'
+else:
+    userNameKey = 'USER'
 try:
-    USER_LIB_PATH_DEFAULT = os.path.join(USER_LIB_BASE_PATH_DEFAULT, os.environ['USER'])
+    USER_LIB_PATH_DEFAULT = os.path.join(USER_LIB_BASE_PATH_DEFAULT, os.environ.get(userNameKey))
 except KeyError:
-    USER_LIB_PATH_DEFAULT = ''
+    USER_LIB_PATH_DEFAULT = os.path.join(USER_LIB_BASE_PATH_DEFAULT, 'UserNodes')
 
 ANACONDA_PREFIX='/opt/anaconda1anaconda2anaconda3' # is this needed?
 GPI_PREFIX = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Fixes a minor bug where generating the user node library (and example node) would crash GPI on Windows.