### PR TITLE
Hotfix - gpi_make failing on C-F build server

### DIFF
--- a/lib/gpi/config.py
+++ b/lib/gpi/config.py
@@ -54,10 +54,7 @@ if Specs.inWindows():
     userNameKey = 'USERNAME'
 else:
     userNameKey = 'USER'
-try:
-    USER_LIB_PATH_DEFAULT = os.path.join(USER_LIB_BASE_PATH_DEFAULT, os.environ.get(userNameKey))
-except KeyError:
-    USER_LIB_PATH_DEFAULT = os.path.join(USER_LIB_BASE_PATH_DEFAULT, 'UserNodes')
+USER_LIB_PATH_DEFAULT = os.path.join(USER_LIB_BASE_PATH_DEFAULT, os.environ.get(userNameKey, 'UserNodes'))
 
 ANACONDA_PREFIX='/opt/anaconda1anaconda2anaconda3' # is this needed?
 GPI_PREFIX = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
os.environ.get defaults to None if it can't find the key, which wasn't caught by the KeyError exception. Instead, just use os.environ.get's ability to handle a default return value in case it can't find the key.