### PR TITLE
Add support to OSX Big Sur & fallbacks

### DIFF
--- a/lib/gpi/GLObjects.py
+++ b/lib/gpi/GLObjects.py
@@ -57,8 +57,27 @@ from .logger import manager
 log = manager.getLogger(__name__)
 
 try:
-    import OpenGL, OpenGL.GL, OpenGL.GLU, OpenGL.GLUT
-    from OpenGL import GL, GLU
+    try:
+        import OpenGL, OpenGL.GL, OpenGL.GLU, OpenGL.GLUT
+        from OpenGL import GL, GLU
+    
+    # fallback for OpenGl Module import source
+    except ImportError:
+        # https://stackoverflow.com/questions/63475461/unable-to-import-opengl-gl-in-python-on-macos
+        print('Patching OpenGL import for Big Sur (OSX)')
+        from ctypes import util
+        orig_util_find_library = util.find_library
+        
+        # retrieving the OpenGl Modules from its directory instead of cache
+        def new_util_find_library (name):
+            res = orig_util_find_library (name)
+            if res: return res
+            return '/System/Library/Frameworks/' + name + '.framework/' + name
+
+        util.find_library = new_util_find_library
+        
+        import OpenGL, OpenGL.GL, OpenGL.GLU, OpenGL.GLUT
+        from OpenGL import GL, GLU
 
 except ImportError:
     log.warn('OpenGL was not found, GL objects and windows will not be supported in this session.')

--- a/lib/gpi/sysspecs.py
+++ b/lib/gpi/sysspecs.py
@@ -106,6 +106,11 @@ class SysSpecs(object):
             lim = 10000
             hard_lim = 10000
 
+        # if the hard limit is infinite (unlimited resources) cap it at 10000
+        if hard_lim == resource.RLIM_INFINITY:
+            lim = 10000
+            hard_lim = 10000
+
         while (not self._inWindows) and (not maxFound):
             try:
                 lim += 10


### PR DESCRIPTION
- Added a cap for the amount of resources if the max limit is infinite
  in the system specs (sysspecs.py)
- Add import fallback to OpenGl Module in case it is being retrieved from a
  cache that does not contain it (GLObjects.py)